### PR TITLE
Switch to manual dispatching

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,6 @@
 name: Unit test coverage
 
-on:
-  - push
-  - pull_request
+on: workflow_dispatch
 
 jobs:
   tests:


### PR DESCRIPTION
Scrutinizer CI can no longer access the repository within the organization. Until the permission issue is fixed, I am essentially disabling this workflow.